### PR TITLE
ADF-1754 Fix incompatibility with the twenty twenty-two theme

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,11 @@
+2022-10-04 - version 1.5.2
+* Make the plugin compatible with the twenty twenty-two theme
+
 2022-08-03 - version 1.5.1
 * Fix loading the js source map
 
 2022-08-03 - version 1.5.0
-* Display a help tip when the save button in settings might be hidden due to PayPal extension.
+* Display a help tip when the save button in settings might be hidden due to PayPal extension
 
 2022-07-26 - version 1.4.12
 * Fix version used

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "addressfinder-woocommerce",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "addressfinder-woocommerce",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "An address verification tool for woocommerce stores serving New Zealand and Australian customers",
   "main": "src/index.js",
   "repository": "git@github.com:AddressFinder/addressfinder-woocommerce.git",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, addressfinder, address, autocomplete, new zealand, australia,
 Requires at least: 4.1
 Tested up to: 6.0.1
 WC tested up to: 6.7.0
-Stable tag: 1.5.1
+Stable tag: 1.5.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -147,10 +147,12 @@ The AddressFinder website has a large [FAQ section](https://addressfinder.com.au
 
 
 == Changelog ==
+= 1.5.2 =
+* Make the plugin compatible with the twenty twenty-two theme
 = 1.5.1 =
 * Fix loading the js source map
 = 1.5.0 =
-* Display a help tip when the save button in settings might be hidden due to PayPal extension.
+* Display a help tip when the save button in settings might be hidden due to PayPal extension
 = 1.4.12 =
 * Fix version used
 = 1.4.11 =

--- a/src/woocommerce_plugin.js
+++ b/src/woocommerce_plugin.js
@@ -5,7 +5,7 @@ import { PageManager, MutationManager } from '@addressfinder/addressfinder-webpa
   class WooCommercePlugin {
     constructor() {
 
-      this.version = "1.5.1"
+      this.version = "1.5.2"
 
       // Manages the mapping of the form configurations to the DOM.
       this.PageManager = null

--- a/woocommerce-addressfinder.php
+++ b/woocommerce-addressfinder.php
@@ -3,7 +3,7 @@
 	AddressFinder plugin for autocompleting addresses in WooCommerce for New Zealand and Australia
 	Plugin Name: AddressFinder
 	Plugin URI: https://github.com/AddressFinder/woocommerce-addressfinder
-	Version: 1.5.1
+	Version: 1.5.2
 	Author: AddressFinder
 	Description: Woocommerce address finder plugin for autocompleting addresses in New Zealand and Australia
 
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ADDRESSFINDER_WOOCOMMERCE_VERSION' ) ) {
-	define( 'ADDRESSFINDER_WOOCOMMERCE_VERSION', '1.5.1' );
+	define( 'ADDRESSFINDER_WOOCOMMERCE_VERSION', '1.5.2' );
 }
 
 /**
@@ -64,7 +64,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
 		echo "\n</script>";
 
-		wp_enqueue_script( 'addressfinder_js', plugins_url( 'addressfinder.js', __FILE__ ), array(), ADDRESSFINDER_WOOCOMMERCE_VERSION );
+		wp_enqueue_script( 'addressfinder_js', plugins_url( 'addressfinder.js', __FILE__ ), array(), ADDRESSFINDER_WOOCOMMERCE_VERSION, true );
 	}
 
 	add_filter( 'woocommerce_get_settings_checkout', 'addressfinder_settings', 10, 1 );


### PR DESCRIPTION
The theme uses webpacker to pack and deploy scripts which caused the `document` passed into our script to not be the DOM document but some kind of webpacker object.

The fix is to include the addressfinder javascript in the footer instead of the header which causes the script to be loaded the old and "boring" way.