### PR TITLE
ADF-2874 Add EV and PV to the WooCommerce plugin.

### DIFF
--- a/src/email_widget.js
+++ b/src/email_widget.js
@@ -1,0 +1,25 @@
+export default class EmailWidget {
+  constructor(document, addressfinderConfig, safeParseJSONObject){
+    this.document = document
+    this.addressfinderConfig = addressfinderConfig
+    this.safeParseJSONObject = safeParseJSONObject
+  }
+
+  loadEmailWidget() {
+    let s = this.document.createElement("script");
+    s.src = 'https://api.addressfinder.io/assets/email/v2/widget.js'
+    s.async = 1;
+    s.onload = this._initialiseEmailWidget.bind(this)
+    this.document.body.appendChild(s)
+  }
+
+  _initialiseEmailWidget(){
+    let conf = {
+      key: this.addressfinderConfig.key_nz || this.addressfinderConfig.key_au || this.addressfinderConfig.key
+    }
+
+    conf.rules = this.safeParseJSONObject(this.addressfinderConfig.email.rules)
+
+    new AddressfinderEmail.Email.Widget("input[type=email]", conf.key, conf);
+  };
+}

--- a/src/phone_widget.js
+++ b/src/phone_widget.js
@@ -1,0 +1,48 @@
+export default class PhoneWidget {
+  constructor(document, addressfinderConfig, safeParseJSONObject){
+    this.document = document
+    this.addressfinderConfig = addressfinderConfig
+    this.safeParseJSONObject = safeParseJSONObject
+
+    this.countryElement = document.getElementById('billing_country')
+    this.phoneLoaded = false
+    this.previousCountry = null
+  }
+
+  loadPhoneWidget() {
+    let s = this.document.createElement("script");
+    s.src = 'http://api.addressfinder.io/assets/phone/v2/widget.js'
+    s.async = 1;
+    s.onload = this._initialisePhoneWidget.bind(this)
+    this.document.body.appendChild(s)
+  }
+
+  _initialisePhoneWidget(){
+    let conf = {
+      key: this.addressfinderConfig.key_nz || this.addressfinderConfig.key_au || this.addressfinderConfig.key,
+      defaultCountryCode: this.addressfinderConfig.phone.defaultCountryCode,
+      countrySelect: "#billing_country"
+    }
+
+    conf.rules = this.safeParseJSONObject(this.addressfinderConfig.phone.rules)
+
+    new AddressfinderPhone.Phone.Widget("input[type=tel]", conf.key, conf);
+
+    if (this.countryElement) {
+      this.phoneLoaded = true
+      this.previousCountry = this.countryElement.value
+    }
+  }
+
+  // Phone widget needs to know there has been a change.
+  checkForCountryChange() {
+    if (this.phoneLoaded && this.countryElement.value != this.previousCountry) {
+      try {
+        this.previousCountry = this.countryElement.value
+        this.countryElement.dispatchEvent(new Event("change", { bubbles: false }));
+      } catch (error) {
+        // do nothing
+      }
+    }
+  }
+}

--- a/src/woocommerce_plugin.js
+++ b/src/woocommerce_plugin.js
@@ -1,17 +1,22 @@
 import ConfigManager from './config_manager'
+import PhoneWidget from './phone_widget'
+import EmailWidget from './email_widget'
 import { PageManager, MutationManager } from '@addressfinder/addressfinder-webpage-tools'
 
 (function (d, w) {
   class WooCommercePlugin {
     constructor() {
 
-      this.version = "1.6.1"
+      this.version = "1.6.2"
 
       // Manages the mapping of the form configurations to the DOM.
       this.PageManager = null
 
       // Manages the form configurations, and creates any dynamic forms
       this.ConfigManager = null
+
+      this.PhoneWidget = null
+      this.EmailWidget = null
 
       this._initPlugin = this._initPlugin.bind(this)
 
@@ -28,8 +33,28 @@ import { PageManager, MutationManager } from '@addressfinder/addressfinder-webpa
         this.PageManager.reload(addressFormConfigurations)
       }
 
-      // Phone widget needs to know there has been a change.
-      checkForCountryChange()
+      // Country selection by a user triggers mutation events, it does not trigger event listeners.
+      if (this.PhoneWidget) {
+        this.PhoneWidget.checkForCountryChange()
+      }
+    }
+
+    _safeParseJSONObject(jsonObject) {
+      if (jsonObject == undefined) {
+        return null;
+      }
+
+      try {
+        jsonObject = JSON.parse(jsonObject);
+      } catch (e) {
+        if (w.AddressFinderConfig.debug) {
+          alert('Invalid widget option: ' + jsonObject);
+        }
+
+        return null;
+      }
+
+      return jsonObject;
     }
 
     _initOnDOMLoaded(event, repetitions) {
@@ -61,9 +86,9 @@ import { PageManager, MutationManager } from '@addressfinder/addressfinder-webpa
     }
 
     _initPlugin() {
-      let parsedWidgetOptions = _safeParseJSONObject(w.AddressFinderConfig.widget_options);
-      let parsedNZWidgetOptions = _safeParseJSONObject(w.AddressFinderConfig.nz_widget_options);
-      let parsedAUWidgetOptions = _safeParseJSONObject(w.AddressFinderConfig.au_widget_options);
+      let parsedWidgetOptions = this._safeParseJSONObject(w.AddressFinderConfig.widget_options);
+      let parsedNZWidgetOptions = this._safeParseJSONObject(w.AddressFinderConfig.nz_widget_options);
+      let parsedAUWidgetOptions = this._safeParseJSONObject(w.AddressFinderConfig.au_widget_options);
 
       const widgetConfig = {
         nzKey: w.AddressFinderConfig.key_nz || w.AddressFinderConfig.key || w.AddressFinderConfig.key_au,
@@ -96,8 +121,15 @@ import { PageManager, MutationManager } from '@addressfinder/addressfinder-webpa
 
       w.AddressFinder._woocommercePlugin = this.PageManager
 
-      _loadEmailWidget()
-      _loadPhoneWidget()
+      if (w.AddressFinderConfig.email) {
+        this.EmailWidget = new EmailWidget(d, w.AddressFinderConfig, this._safeParseJSONObject)
+        this.EmailWidget.loadEmailWidget()
+      }
+
+      if (w.AddressFinderConfig.phone) {
+        this.PhoneWidget = new PhoneWidget(d, w.AddressFinderConfig, this._safeParseJSONObject)
+        this.PhoneWidget.loadPhoneWidget()
+      }
     }
 
     _setVersionNumbers() {
@@ -114,90 +146,6 @@ import { PageManager, MutationManager } from '@addressfinder/addressfinder-webpa
       w.AddressFinderConfig.debug = true
       this._initPlugin()
     }
-  }
-
-  function _loadEmailWidget() {
-    if (w.AddressFinderConfig.email) {
-
-      let s = document.createElement("script");
-      s.src = 'https://api.addressfinder.io/assets/email/v2/widget.js'
-      s.async = 1;
-      s.onload = _initialiseEmailWidget
-      d.body.appendChild(s)
-    }
-
-    function _initialiseEmailWidget(){
-      let conf = {
-        key: w.AddressFinderConfig.key_nz || w.AddressFinderConfig.key_au || w.AddressFinderConfig.key,
-      }
-
-      conf.rules = _safeParseJSONObject(w.AddressFinderConfig.email.rules)
-
-      new AddressfinderEmail.Email.Widget("input[type=email]", conf.key, conf);
-    };
-  }
-
-  var phoneLoaded = false
-  var previousCountry = null
-  var countryElement = null
-  function _loadPhoneWidget() {
-    if (w.AddressFinderConfig.phone) {
-
-      let s = document.createElement("script");
-      s.src = 'http://api.addressfinder.io/assets/phone/v2/widget.js'
-      s.async = 1;
-      s.onload = _initialisePhoneWidget
-      d.body.appendChild(s)
-    }
-
-    countryElement = document.getElementById('billing_country')
-
-    function _initialisePhoneWidget(){
-      let conf = {
-        key: w.AddressFinderConfig.key_nz || w.AddressFinderConfig.key_au || w.AddressFinderConfig.key,
-        defaultCountryCode: w.AddressFinderConfig.phone.defaultCountryCode,
-        countrySelect: "#billing_country"
-      }
-
-      conf.rules = _safeParseJSONObject(w.AddressFinderConfig.phone.rules)
-
-      new AddressfinderPhone.Phone.Widget("input[type=tel]", conf.key, conf);
-
-      if (countryElement) {
-        phoneLoaded = true
-        previousCountry = countryElement.value
-      }
-    };
-  }
-
-  // Phone widget needs to know there has been a change.
-  function checkForCountryChange() {
-    if (phoneLoaded && countryElement.value != previousCountry) {
-      try {
-        previousCountry = countryElement.value
-        countryElement.dispatchEvent(new Event("change", { bubbles: false }));
-      } catch (error) {
-        // do nothing
-      }
-    }
-  }
-
-  function _safeParseJSONObject(jsonObject) {
-    if (jsonObject == undefined) {
-      return null;
-    }
-
-    try {
-      jsonObject = JSON.parse(jsonObject);
-    } catch (e) {
-      if (w.AddressFinderConfig.debug) {
-        alert('Invalid widget option: ' + jsonObject);
-      }
-
-      return null;
-    }
-
-    return jsonObject;
   }
 
   var s = d.createElement('script')

--- a/woocommerce-addressfinder.php
+++ b/woocommerce-addressfinder.php
@@ -20,6 +20,8 @@ if ( ! defined( 'ADDRESSFINDER_WOOCOMMERCE_VERSION' ) ) {
 
 /**
  * Check if WooCommerce is active
+ *
+ * @since 1.0.0
  */
 if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
 	add_action( 'woocommerce_after_checkout_form', 'add_addressfinder_widget' );
@@ -44,22 +46,22 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 		$af_widget_nz_po_box = esc_attr( get_option( 'af-widget-nz-pobox' ) );
 		$af_widget_au_po_box = esc_attr( get_option( 'af-widget-au-pobox' ) );
 
-    // email
-    $af_ev_widget_enabled = esc_attr( get_option( 'af-ev-widget-enabled' ) );
-    $af_ev_widget_public = esc_attr( get_option( 'af-ev-widget-public' ) );
-    $af_ev_widget_role = esc_attr( get_option( 'af-ev-widget-role' ) );
-    $af_ev_widget_disposable = esc_attr( get_option( 'af-ev-widget-disposable' ) );
-    $af_ev_widget_unverified = esc_attr( get_option( 'af-ev-widget-unverified' ) );
-    $af_ev_widget_options = get_option( 'af-ev-widget-options' );
+		// email.
+		$af_ev_widget_enabled = esc_attr( get_option( 'af-ev-widget-enabled' ) );
+		$af_ev_widget_public = esc_attr( get_option( 'af-ev-widget-public' ) );
+		$af_ev_widget_role = esc_attr( get_option( 'af-ev-widget-role' ) );
+		$af_ev_widget_disposable = esc_attr( get_option( 'af-ev-widget-disposable' ) );
+		$af_ev_widget_unverified = esc_attr( get_option( 'af-ev-widget-unverified' ) );
+		$af_ev_widget_options = get_option( 'af-ev-widget-options' );
 
-    // phone
-    $af_pv_widget_enabled = esc_attr( get_option( 'af-pv-widget-enabled' ) );
-    $af_pv_default_country = esc_attr( get_option( 'af-pv-widget-default-country' ) );
-    $af_pv_allowed_countries = esc_attr( get_option( 'af-pv-widget-allowed-countries' ) );
-    $af_pv_widget_non_mobile = esc_attr( get_option( 'af-pv-widget-non-mobile' ) );
-    $af_pv_widget_disallowed_country = esc_attr( get_option( 'af-pv-widget-disallowed-country' ) );
-    $af_pv_widget_unverified = esc_attr( get_option( 'af-pv-widget-unverified' ) );
-    $af_pv_widget_options = get_option( 'af-pv-widget-options' );
+		// phone.
+		$af_pv_widget_enabled = esc_attr( get_option( 'af-pv-widget-enabled' ) );
+		$af_pv_default_country = esc_attr( get_option( 'af-pv-widget-default-country' ) );
+		$af_pv_allowed_countries = esc_attr( get_option( 'af-pv-widget-allowed-countries' ) );
+		$af_pv_widget_non_mobile = esc_attr( get_option( 'af-pv-widget-non-mobile' ) );
+		$af_pv_widget_disallowed_country = esc_attr( get_option( 'af-pv-widget-disallowed-country' ) );
+		$af_pv_widget_unverified = esc_attr( get_option( 'af-pv-widget-unverified' ) );
+		$af_pv_widget_options = get_option( 'af-pv-widget-options' );
 
 		$addressfinder_js   = file_get_contents( $path . 'addressfinder.js' );
 		echo "<script>\nvar AddressFinderConfig = {};\n";
@@ -75,84 +77,91 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 		if ( null !== $af_widget_options && ! empty( trim( $af_widget_options ) ) ) {
 			printf( "AddressFinderConfig.widget_options = '%s';\n", wp_json_encode( json_decode( $af_widget_options ) ) );
 		} else {
-      $au_post_box = ($af_widget_au_po_box == 'yes') ? "1" : "0";
-      $nz_post_box = ($af_widget_nz_po_box == 'yes') ? "1" : "0";
+			$au_post_box = ( 'yes' == $af_widget_au_po_box ) ? '1' : '0';
+			$nz_post_box = ( 'yes' == $af_widget_nz_po_box ) ? '1' : '0';
 
-      if ('postal_and_physical' == $af_widget_au_options) {
-        printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"source": "gnaf,paf", "post_box": "' . $au_post_box . '"}}')));
-      } elseif ('postal' == $af_widget_au_options) {
-        printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"source": "paf", "post_box": "' . $au_post_box . '"}}')));
-      } else {
-        printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"source": "gnaf", "post_box": "' . $au_post_box . '"}}')));
-      }
+			if ( 'postal_and_physical' == $af_widget_au_options ) {
+				printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode( json_decode( '{"address_params": {"source": "gnaf,paf", "post_box": "' . $au_post_box . '"}}' ) ) );
+			} elseif ( 'postal' == $af_widget_au_options ) {
+				printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode( json_decode( '{"address_params": {"source": "paf", "post_box": "' . $au_post_box . '"}}' ) ) );
+			} else {
+				printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode( json_decode( '{"address_params": {"source": "gnaf", "post_box": "' . $au_post_box . '"}}' ) ) );
+			}
 
-      if ('postal_and_physical' == $af_widget_nz_options) {
-        printf( "AddressFinderConfig.nz_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"post_box": "' . $nz_post_box . '"}}')));
-      } else {
-        printf( "AddressFinderConfig.nz_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"delivered": "1", "post_box": "' . $nz_post_box . '"}}')));
-      }
-    }
+			if ( 'postal_and_physical' == $af_widget_nz_options ) {
+				printf( "AddressFinderConfig.nz_widget_options = '%s';\n", wp_json_encode( json_decode( '{"address_params": {"post_box": "' . $nz_post_box . '"}}' ) ) );
+			} else {
+				printf( "AddressFinderConfig.nz_widget_options = '%s';\n", wp_json_encode( json_decode( '{"address_params": {"delivered": "1", "post_box": "' . $nz_post_box . '"}}' ) ) );
+			}
+		}
 
-    // Email Settings
-    if ('yes' == $af_ev_widget_enabled) {
-      echo "AddressFinderConfig.email = {};\n";
+		// Email Settings.
+		if ( 'yes' == $af_ev_widget_enabled ) {
+			echo "AddressFinderConfig.email = {};\n";
 
-      if (null !== $af_ev_widget_options && ! empty( trim( $af_ev_widget_options ))) {
-        printf( "AddressFinderConfig.email.rules = '%s';\n", wp_json_encode( json_decode($af_ev_widget_options)));
-      } else {
-        $public_rule     = ($af_ev_widget_public == 'yes') ? "allow" : "block";
-        $role_rule       = ($af_ev_widget_role == 'yes') ? "allow" : "block";
-        $disposable_rule = ($af_ev_widget_disposable == 'yes') ? "allow" : "block";
-        $unverified_rule = ($af_ev_widget_unverified == 'yes') ? "allow" : "block";
+			if ( null !== $af_ev_widget_options && ! empty( trim( $af_ev_widget_options ) ) ) {
+				printf( "AddressFinderConfig.email.rules = '%s';\n", wp_json_encode( json_decode( $af_ev_widget_options ) ) );
+			} else {
+				$public_rule     = ( 'yes' == $af_ev_widget_public ) ? 'allow' : 'block';
+				$role_rule       = ( 'yes' == $af_ev_widget_role ) ? 'allow' : 'block';
+				$disposable_rule = ( 'yes' == $af_ev_widget_disposable ) ? 'allow' : 'block';
+				$unverified_rule = ( 'yes' == $af_ev_widget_unverified ) ? 'allow' : 'block';
 
-        printf("AddressFinderConfig.email.rules = '%s';\n", wp_json_encode(json_decode('{"public": {"rule": "' . $public_rule . '"}, "role": {"rule": "' . $role_rule . '"}, "disposable": {"rule": "' . $disposable_rule . '"}, "unverified": {"rule": "' . $unverified_rule . '"}}')));
-      }
-    }
+				printf( "AddressFinderConfig.email.rules = '%s';\n", wp_json_encode( json_decode( '{"public": {"rule": "' . $public_rule . '"}, "role": {"rule": "' . $role_rule . '"}, "disposable": {"rule": "' . $disposable_rule . '"}, "unverified": {"rule": "' . $unverified_rule . '"}}' ) ) );
+			}
+		}
 
-    // Phone Settings
-    if ('yes' == $af_pv_widget_enabled) {
-      echo "AddressFinderConfig.phone = {};\n";
+		// Phone Settings.
+		if ( 'yes' == $af_pv_widget_enabled ) {
+			echo "AddressFinderConfig.phone = {};\n";
 
-      if ( $af_pv_default_country ) {
-        printf( "AddressFinderConfig.phone.defaultCountryCode = '%s';\n", esc_js( $af_pv_default_country ) );
-      }
+			if ( $af_pv_default_country ) {
+				printf( "AddressFinderConfig.phone.defaultCountryCode = '%s';\n", esc_js( $af_pv_default_country ) );
+			}
 
-      if ( $af_pv_allowed_countries ) {
-        printf( "AddressFinderConfig.phone.allowedCountryCodes = '%s';\n", esc_js( $af_pv_allowed_countries ) );
-      }
+			if ( $af_pv_allowed_countries ) {
+				printf( "AddressFinderConfig.phone.allowedCountryCodes = '%s';\n", esc_js( $af_pv_allowed_countries ) );
+			}
 
-      if (null !== $af_pv_widget_options && ! empty( trim( $af_pv_widget_options ))) {
-        printf( "AddressFinderConfig.phone.rules = '%s';\n", wp_json_encode( json_decode($af_pv_widget_options)));
-      } else {
-        $non_mobile_rule         = ($af_pv_widget_non_mobile == 'yes') ? "allow" : "block";
-        $disallowed_country_rule = ($af_pv_widget_disallowed_country == 'yes') ? "allow" : "block";
-        $unverified_phone_rule         = ($af_pv_widget_unverified == 'yes') ? "allow" : "block";
+			if ( null !== $af_pv_widget_options && ! empty( trim( $af_pv_widget_options ) ) ) {
+				printf( "AddressFinderConfig.phone.rules = '%s';\n", wp_json_encode( json_decode( $af_pv_widget_options ) ) );
+			} else {
+				$non_mobile_rule         = ( 'yes' == $af_pv_widget_non_mobile ) ? 'allow' : 'block';
+				$disallowed_country_rule = ( 'yes' == $af_pv_widget_disallowed_country ) ? 'allow' : 'block';
+				$unverified_phone_rule   = ( 'yes' == $af_pv_widget_unverified ) ? 'allow' : 'block';
 
-        printf("AddressFinderConfig.phone.rules = '%s';\n", wp_json_encode(json_decode('{"nonMobile": {"rule": "' . $non_mobile_rule . '"}, "countryNotAllowed": {"rule": "' . $disallowed_country_rule . '"}, "unverified": {"rule": "' . $unverified_phone_rule . '"}}')));
-      }
-    }
+				printf( "AddressFinderConfig.phone.rules = '%s';\n", wp_json_encode( json_decode( '{"nonMobile": {"rule": "' . $non_mobile_rule . '"}, "countryNotAllowed": {"rule": "' . $disallowed_country_rule . '"}, "unverified": {"rule": "' . $unverified_phone_rule . '"}}' ) ) );
+			}
+		}
 
-    echo "\n</script>";
+		echo "\n</script>";
 
 		wp_enqueue_script( 'addressfinder_js', plugins_url( 'addressfinder.js', __FILE__ ), array(), ADDRESSFINDER_WOOCOMMERCE_VERSION, true );
 	}
 
-	// Add the tab to the tabs array
+	/**
+	 * Add the tab to the tabs array.
+	 *
+	 * @param array $settings_tabs adds additional settings.
+	 */
 	function filter_addressfinder_settings_tabs_array( $settings_tabs ) {
-    $settings_tabs['addressfinder-settings'] = __( 'Addressfinder', 'woocommerce' );
+		$settings_tabs['addressfinder-settings'] = __( 'Addressfinder', 'woocommerce' );
 
-    return $settings_tabs;
+		return $settings_tabs;
 	}
 	add_filter( 'woocommerce_settings_tabs_array', 'filter_addressfinder_settings_tabs_array', 99 );
 	add_filter( 'woocommerce_settings_addressfinder-settings', 'add_settings', 10, 1 );
 
-	function add_settings( ) {
+	/**
+	 * Add settings.
+	 */
+	function add_settings() {
 		return WC_Admin_Settings::output_fields( addressfinder_settings() );
 	}
 	/**
 	 * Injects AF related settings into the AF settings page
 	 */
-	function addressfinder_settings( ) {
+	function addressfinder_settings() {
 
 		$settings = array();
 
@@ -199,18 +208,18 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			);
 		}
 
-    $settings[] = array(
+		$settings[] = array(
 			'type' => 'sectionend',
 			'id'   => 'addressfinder-general',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name' => __( 'Address Verification', 'text-domain' ),
 			'type' => 'title',
 			'id'   => 'addressfinder-widget',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name'    => __( 'Default Country', 'text-domain' ),
 			'desc'    => __( 'If your checkout page does not have a country select field, addresses from this country will be displayed.', 'text-domain' ),
 			'id'      => 'af-default-country',
@@ -222,49 +231,49 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			),
 		);
 
-    $settings[] = array(
-      'name'    => __( 'Australian Address Options', 'text-domain' ),
+		$settings[] = array(
+			'name'    => __( 'Australian Address Options', 'text-domain' ),
 			'id'      => 'af-widget-au-options',
 			'default' => 'postal_and_physical',
 			'type'    => 'radio',
 			'options' => array(
-        'postal_and_physical' => __( 'Search all addresses (Postal and Physical)', 'text-domain' ),
+				'postal_and_physical' => __( 'Search all addresses (Postal and Physical)', 'text-domain' ),
 				'postal' => __( 'Search Australia Post delivered addresses only', 'text-domain' ),
 				'physical' => __( 'Search physical addresses only', 'text-domain' ),
 			),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'id'   => 'af-widget-au-pobox',
 			'type' => 'checkbox',
 			'desc' => __( 'Include PO Boxes', 'text-domain' ),
-      'default' => 'yes'
+			'default' => 'yes',
 		);
 
-    $settings[] = array(
-      'name'    => __( 'New Zealand Address Options', 'text-domain' ),
+		$settings[] = array(
+			'name'    => __( 'New Zealand Address Options', 'text-domain' ),
 			'id'      => 'af-widget-nz-options',
 			'default' => 'postal_and_physical',
 			'type'    => 'radio',
 			'options' => array(
-        'postal_and_physical' => __( 'Search all addresses (Postal and Physical)', 'text-domain' ),
-				'postal' => __( 'Search New Zealand Post delivered addresses only', 'text-domain' )
+				'postal_and_physical' => __( 'Search all addresses (Postal and Physical)', 'text-domain' ),
+				'postal' => __( 'Search New Zealand Post delivered addresses only', 'text-domain' ),
 			),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'id'   => 'af-widget-nz-pobox',
 			'type' => 'checkbox',
 			'desc' => __( 'Include PO Boxes', 'text-domain' ),
-      'default' => 'yes'
+			'default' => 'yes',
 		);
 
 		$settings[] = array(
 			'name'        => __( 'Advanced Javascript Options', 'text-domain' ),
 			'id'          => 'af-widget-options',
 			'type'        => 'textarea',
-      'desc_tip' => __( 'This will override the above options.', 'text-domain' ),
-      'placeholder' => __( 'Eg: {"address_params": {"source": "gnaf,paf"}}', 'text-domain' ),
+			'desc_tip' => __( 'This will override the above options.', 'text-domain' ),
+			'placeholder' => __( 'Eg: {"address_params": {"source": "gnaf,paf"}}', 'text-domain' ),
 			'desc'        => __( '<p>Examples can be found <a href="https://addressfinder.nz/docs/code-examples/">here</a>.</p>', 'text-domain' ),
 		);
 
@@ -273,119 +282,119 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			'id'   => 'addressfinder-widget',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name' => __( 'Email Verification', 'text-domain' ),
 			'type' => 'title',
 			'id'   => 'addressfinder-ev-widget',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name' => __( 'Enable', 'text-domain' ),
 			'id'   => 'af-ev-widget-enabled',
 			'type' => 'checkbox',
 			'desc' => __( 'Verify email addresses at the point of capture', 'text-domain' ),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name' => __( 'Allowed Email Types', 'text-domain' ),
 			'id'   => 'af-ev-widget-public',
 			'type' => 'checkbox',
 			'desc' => __( 'Public', 'text-domain' ),
-      'default' => 'yes'
+			'default' => 'yes',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'id'   => 'af-ev-widget-role',
 			'type' => 'checkbox',
 			'desc' => __( 'Role', 'text-domain' ),
-      'default' => 'yes'
+			'default' => 'yes',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'id'   => 'af-ev-widget-disposable',
 			'type' => 'checkbox',
 			'desc' => __( 'Disposable', 'text-domain' ),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'id'   => 'af-ev-widget-unverified',
 			'type' => 'checkbox',
 			'desc' => __( 'Unverified', 'text-domain' ),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name'        => __( 'Advanced Email Rules', 'text-domain' ),
 			'id'          => 'af-ev-widget-options',
 			'type'        => 'textarea',
-      'desc_tip' => __( 'This will override the above allowed email types.', 'text-domain' ),
-      'placeholder' => __( 'Eg: {"public": {"rule": "warn"}}', 'text-domain' ),
+			'desc_tip' => __( 'This will override the above allowed email types.', 'text-domain' ),
+			'placeholder' => __( 'Eg: {"public": {"rule": "warn"}}', 'text-domain' ),
 			'desc'        => __( '<p>Examples can be found <a target="_blank" href="https://addressfinder.nz/docs/email/advanced_usage/#custom-rules-messages">here</a>.</p>', 'text-domain' ),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'type' => 'sectionend',
 			'id'   => 'addressfinder-ev-widget',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name' => __( 'Phone Verification', 'text-domain' ),
 			'type' => 'title',
 			'id'   => 'addressfinder-pv-widget',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name' => __( 'Enable', 'text-domain' ),
 			'id'   => 'af-pv-widget-enabled',
 			'type' => 'checkbox',
 			'desc' => __( 'Verify phone numbers at the point of capture', 'text-domain' ),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name'        => __( 'Default Country', 'text-domain' ),
 			'id'          => 'af-pv-widget-default-country',
 			'type'        => 'text',
 			'desc'        => __( 'Used to determine what location to query.', 'text-domain' ),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name'        => __( 'Allowed Countries', 'text-domain' ),
 			'id'          => 'af-pv-widget-allowed-countries',
 			'type'        => 'text',
-      'placeholder' => __( 'AU,NZ', 'text-domain' ),
+			'placeholder' => __( 'AU,NZ', 'text-domain' ),
 			'desc'        => __( '<p>Seperate country codes by a comma.</p><p>A full list of Country Codes can be found <a target="_blank" href="https://www.iban.com/country-codes">here</a>.</p>', 'text-domain' ),
 		);
 
-    $settings[] = array(
-      'name' => __( 'Allowed Line Types', 'text-domain' ),
- 			'id'   => 'af-pv-widget-non-mobile',
+		$settings[] = array(
+			'name' => __( 'Allowed Line Types', 'text-domain' ),
+			'id'   => 'af-pv-widget-non-mobile',
 			'type' => 'checkbox',
 			'desc' => __( 'Non Mobile', 'text-domain' ),
-      'default' => 'yes'
+			'default' => 'yes',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'id'   => 'af-pv-widget-disallowed-country',
 			'type' => 'checkbox',
 			'desc' => __( 'Disallowed Countries', 'text-domain' ),
-      'default' => 'yes'
+			'default' => 'yes',
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'id'   => 'af-pv-widget-unverified',
 			'type' => 'checkbox',
 			'desc' => __( 'Unverified', 'text-domain' ),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'name'        => __( 'Advanced Phone Rules', 'text-domain' ),
 			'id'          => 'af-pv-widget-options',
 			'type'        => 'textarea',
-      'desc_tip' => __( 'This will override the above accepted line types.', 'text-domain' ),
-      'placeholder' => __( 'Eg: {"unverified": {"rule": "warn"}}', 'text-domain' ),
+			'desc_tip' => __( 'This will override the above accepted line types.', 'text-domain' ),
+			'placeholder' => __( 'Eg: {"unverified": {"rule": "warn"}}', 'text-domain' ),
 			'desc'        => __( '<p>Examples can be found <a target="_blank" href="https://addressfinder.nz/docs/phone/advanced_usage/#custom-rules-messages">here</a>.</p>', 'text-domain' ),
 		);
 
-    $settings[] = array(
+		$settings[] = array(
 			'type' => 'sectionend',
 			'id'   => 'addressfinder-pv-widget',
 		);
@@ -393,26 +402,33 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 		return $settings;
 	}
 
-	// Process save the settings
+	/**
+	 * Process save the settings.
+	 */
 	function action_woocommerce_settings_save_addressfinder_settings() {
-    global $current_section;
+		global $current_section;
 
-    $tab_id = 'addressfinder-settings';
+		$tab_id = 'addressfinder-settings';
 
-    // Call settings function
-    $settings = addressfinder_settings();
+		// Call settings function.
+		$settings = addressfinder_settings();
 
-    WC_Admin_Settings::save_fields( $settings );
+		WC_Admin_Settings::save_fields( $settings );
 
-    if ( $current_section ) {
-	    do_action( 'woocommerce_update_options_' . $tab_id . '_' . $current_section );
-    }
+		if ( $current_section ) {
+			/**
+			 * Updating the woocommerce options.
+			 *
+		   * @since 1.0.0
+			 */
+			do_action( 'woocommerce_update_options_' . $tab_id . '_' . $current_section );
+		}
 	}
 	add_action( 'woocommerce_settings_save_addressfinder-settings', 'action_woocommerce_settings_save_addressfinder_settings', 10 );
 
 
 	/**
-	 * Load Addressfinder styles
+	 * Load Addressfinder styles.
 	 */
 	function addressfinder_add_styles() {
 		$plugin_url = plugin_dir_url( __FILE__ );

--- a/woocommerce-addressfinder.php
+++ b/woocommerce-addressfinder.php
@@ -77,8 +77,8 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 		if ( null !== $af_widget_options && ! empty( trim( $af_widget_options ) ) ) {
 			printf( "AddressFinderConfig.widget_options = '%s';\n", wp_json_encode( json_decode( $af_widget_options ) ) );
 		} else {
-			$au_post_box = ( 'yes' == $af_widget_au_po_box ) ? '1' : '0';
-			$nz_post_box = ( 'yes' == $af_widget_nz_po_box ) ? '1' : '0';
+			$au_post_box = ( 'yes' == $af_widget_au_po_box ) ? '0' : '1';
+			$nz_post_box = ( 'yes' == $af_widget_nz_po_box ) ? '0' : '1';
 
 			if ( 'postal_and_physical' == $af_widget_au_options ) {
 				printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode( json_decode( '{"address_params": {"source": "gnaf,paf", "post_box": "' . $au_post_box . '"}}' ) ) );
@@ -389,7 +389,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			'name'        => __( 'Advanced Phone Rules', 'text-domain' ),
 			'id'          => 'af-pv-widget-options',
 			'type'        => 'textarea',
-			'desc_tip' => __( 'This will override the above accepted line types.', 'text-domain' ),
+			'desc_tip' => __( 'This will override the above allowed line types.', 'text-domain' ),
 			'placeholder' => __( 'Eg: {"unverified": {"rule": "warn"}}', 'text-domain' ),
 			'desc'        => __( '<p>Examples can be found <a target="_blank" href="https://addressfinder.nz/docs/phone/advanced_usage/#custom-rules-messages">here</a>.</p>', 'text-domain' ),
 		);

--- a/woocommerce-addressfinder.php
+++ b/woocommerce-addressfinder.php
@@ -34,12 +34,33 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	 * @param string[] $_checkout unused.
 	 */
 	function add_addressfinder_widget( $_checkout ) {
-		$path               = plugin_dir_path( __FILE__ );
-		$af_key_nz          = esc_attr( get_option( 'af-key' ) );
-		$af_key_au          = esc_attr( get_option( 'af-key-au' ) );
-		$af_widget_options  = get_option( 'af-widget-options' );
-		$af_debug           = esc_attr( get_option( 'af-debug' ) );
-		$af_default_country = esc_attr( get_option( 'af-default-country' ) );
+		$path                = plugin_dir_path( __FILE__ );
+		$af_key_nz           = esc_attr( get_option( 'af-key' ) );
+		$af_key_au           = esc_attr( get_option( 'af-key-au' ) );
+		$af_widget_options   = get_option( 'af-widget-options' );
+		$af_default_country  = esc_attr( get_option( 'af-default-country' ) );
+		$af_widget_au_options = esc_attr( get_option( 'af-widget-au-options' ) );
+		$af_widget_nz_options = esc_attr( get_option( 'af-widget-nz-options' ) );
+		$af_widget_nz_po_box = esc_attr( get_option( 'af-widget-nz-pobox' ) );
+		$af_widget_au_po_box = esc_attr( get_option( 'af-widget-au-pobox' ) );
+
+    // email
+    $af_ev_widget_enabled = esc_attr( get_option( 'af-ev-widget-enabled' ) );
+    $af_ev_widget_public = esc_attr( get_option( 'af-ev-widget-public' ) );
+    $af_ev_widget_role = esc_attr( get_option( 'af-ev-widget-role' ) );
+    $af_ev_widget_disposable = esc_attr( get_option( 'af-ev-widget-disposable' ) );
+    $af_ev_widget_unverified = esc_attr( get_option( 'af-ev-widget-unverified' ) );
+    $af_ev_widget_options = get_option( 'af-ev-widget-options' );
+
+    // phone
+    $af_pv_widget_enabled = esc_attr( get_option( 'af-pv-widget-enabled' ) );
+    $af_pv_default_country = esc_attr( get_option( 'af-pv-widget-default-country' ) );
+    $af_pv_allowed_countries = esc_attr( get_option( 'af-pv-widget-allowed-countries' ) );
+    $af_pv_widget_non_mobile = esc_attr( get_option( 'af-pv-widget-non-mobile' ) );
+    $af_pv_widget_disallowed_country = esc_attr( get_option( 'af-pv-widget-disallowed-country' ) );
+    $af_pv_widget_unverified = esc_attr( get_option( 'af-pv-widget-unverified' ) );
+    $af_pv_widget_options = get_option( 'af-pv-widget-options' );
+
 		$addressfinder_js   = file_get_contents( $path . 'addressfinder.js' );
 		echo "<script>\nvar AddressFinderConfig = {};\n";
 
@@ -53,17 +74,65 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
 		if ( null !== $af_widget_options && ! empty( trim( $af_widget_options ) ) ) {
 			printf( "AddressFinderConfig.widget_options = '%s';\n", wp_json_encode( json_decode( $af_widget_options ) ) );
-		}
+		} else {
+      $au_post_box = ($af_widget_au_po_box == 'yes') ? "1" : "0";
+      $nz_post_box = ($af_widget_nz_po_box == 'yes') ? "1" : "0";
 
-		if ( 'yes' == $af_debug ) {
-			echo "AddressFinderConfig.debug = true;\n";
-		}
+      if ('postal_and_physical' == $af_widget_au_options) {
+        printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"source": "gnaf,paf", "post_box": "' . $au_post_box . '"}}')));
+      } elseif ('postal' == $af_widget_au_options) {
+        printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"source": "paf", "post_box": "' . $au_post_box . '"}}')));
+      } else {
+        printf( "AddressFinderConfig.au_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"source": "gnaf", "post_box": "' . $au_post_box . '"}}')));
+      }
 
-		if ( $af_default_country ) {
-			printf( "AddressFinderConfig.default_country = '%s';\n", esc_js( $af_default_country ) );
-		}
+      if ('postal_and_physical' == $af_widget_nz_options) {
+        printf( "AddressFinderConfig.nz_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"post_box": "' . $nz_post_box . '"}}')));
+      } else {
+        printf( "AddressFinderConfig.nz_widget_options = '%s';\n", wp_json_encode(json_decode('{"address_params": {"delivered": "1", "post_box": "' . $nz_post_box . '"}}')));
+      }
+    }
 
-		echo "\n</script>";
+    // Email Settings
+    if ('yes' == $af_ev_widget_enabled) {
+      echo "AddressFinderConfig.email = {};\n";
+
+      if (null !== $af_ev_widget_options && ! empty( trim( $af_ev_widget_options ))) {
+        printf( "AddressFinderConfig.email.rules = '%s';\n", wp_json_encode( json_decode($af_ev_widget_options)));
+      } else {
+        $public_rule     = ($af_ev_widget_public == 'yes') ? "allow" : "block";
+        $role_rule       = ($af_ev_widget_role == 'yes') ? "allow" : "block";
+        $disposable_rule = ($af_ev_widget_disposable == 'yes') ? "allow" : "block";
+        $unverified_rule = ($af_ev_widget_unverified == 'yes') ? "allow" : "block";
+
+        printf("AddressFinderConfig.email.rules = '%s';\n", wp_json_encode(json_decode('{"public": {"rule": "' . $public_rule . '"}, "role": {"rule": "' . $role_rule . '"}, "disposable": {"rule": "' . $disposable_rule . '"}, "unverified": {"rule": "' . $unverified_rule . '"}}')));
+      }
+    }
+
+    // Phone Settings
+    if ('yes' == $af_pv_widget_enabled) {
+      echo "AddressFinderConfig.phone = {};\n";
+
+      if ( $af_pv_default_country ) {
+        printf( "AddressFinderConfig.phone.defaultCountryCode = '%s';\n", esc_js( $af_pv_default_country ) );
+      }
+
+      if ( $af_pv_allowed_countries ) {
+        printf( "AddressFinderConfig.phone.allowedCountryCodes = '%s';\n", esc_js( $af_pv_allowed_countries ) );
+      }
+
+      if (null !== $af_pv_widget_options && ! empty( trim( $af_pv_widget_options ))) {
+        printf( "AddressFinderConfig.phone.rules = '%s';\n", wp_json_encode( json_decode($af_pv_widget_options)));
+      } else {
+        $non_mobile_rule         = ($af_pv_widget_non_mobile == 'yes') ? "allow" : "block";
+        $disallowed_country_rule = ($af_pv_widget_disallowed_country == 'yes') ? "allow" : "block";
+        $unverified_phone_rule         = ($af_pv_widget_unverified == 'yes') ? "allow" : "block";
+
+        printf("AddressFinderConfig.phone.rules = '%s';\n", wp_json_encode(json_decode('{"nonMobile": {"rule": "' . $non_mobile_rule . '"}, "countryNotAllowed": {"rule": "' . $disallowed_country_rule . '"}, "unverified": {"rule": "' . $unverified_phone_rule . '"}}')));
+      }
+    }
+
+    echo "\n</script>";
 
 		wp_enqueue_script( 'addressfinder_js', plugins_url( 'addressfinder.js', __FILE__ ), array(), ADDRESSFINDER_WOOCOMMERCE_VERSION, true );
 	}
@@ -88,10 +157,10 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 		$settings = array();
 
 		$settings[] = array(
-			'name' => __( 'Addressfinder', 'text-domain' ),
+			'name' => __( 'Addressfinder Settings', 'text-domain' ),
 			'type' => 'title',
 			'desc' => __( 'Addressfinder supports Australian and New Zealand data verification services.', 'text-domain' ),
-			'id'   => 'addressfinder-widget',
+			'id'   => 'addressfinder-general',
 		);
 
 		$af_key_nz = esc_attr( get_option( 'af-key' ) );
@@ -102,7 +171,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				'desc_tip' => __( 'The key shown in the Addressfinder portal', 'text-domain' ),
 				'id'       => 'af-key',
 				'type'     => 'text',
-				'desc'     => __( 'Find your Addressfinder Key from <a href="https://portal.addressfinder.net" target="_blank">Addressfinder Portal</a>', 'text-domain' ),
+				'desc'     => __( 'Find your Addressfinder Key from <a href="https://portal.addressfinder.net" target="_blank">Addressfinder Portal</a>.', 'text-domain' ),
 			);
 
 			$settings[] = array(
@@ -110,7 +179,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				'desc_tip' => __( 'The key shown in the Addressfinder Australian portal', 'text-domain' ),
 				'id'       => 'af-key-au',
 				'type'     => 'text',
-				'desc'     => __( 'Find your Addressfinder Key from <a href="https://portal.addressfinder.net" target="_blank">Addressfinder Portal</a>', 'text-domain' ),
+				'desc'     => __( 'Find your Addressfinder Key from <a href="https://portal.addressfinder.net" target="_blank">Addressfinder Portal</a>.', 'text-domain' ),
 			);
 		} elseif ( $af_key_au ) {
 			$settings[] = array(
@@ -118,7 +187,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				'desc_tip' => __( 'The key shown in the Addressfinder Australian portal', 'text-domain' ),
 				'id'       => 'af-key-au',
 				'type'     => 'text',
-				'desc'     => __( 'Find your Addressfinder Key from <a href="https://portal.addressfinder.net" target="_blank">Addressfinder Portal</a>', 'text-domain' ),
+				'desc'     => __( 'Find your Addressfinder Key from <a href="https://portal.addressfinder.net" target="_blank">Addressfinder Portal</a>.', 'text-domain' ),
 			);
 		} else {
 			$settings[] = array(
@@ -126,28 +195,24 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 				'desc_tip' => __( 'The key shown in the Addressfinder portal', 'text-domain' ),
 				'id'       => 'af-key',
 				'type'     => 'text',
-				'desc'     => __( 'Find your Addressfinder Key from <a href="https://portal.addressfinder.net" target="_blank">Addressfinder Portal</a>', 'text-domain' ),
+				'desc'     => __( 'Find your Addressfinder Key from <a href="https://portal.addressfinder.net" target="_blank">Addressfinder Portal</a>.', 'text-domain' ),
 			);
 		}
 
-		$settings[] = array(
-			'name'        => __( 'Widget Options', 'text-domain' ),
-			'id'          => 'af-widget-options',
-			'type'        => 'textarea',
-			'placeholder' => __( 'Eg: {&quot;byline&quot;: true}', 'text-domain' ),
-			'desc'        => __( '<p>Additional options that allow you to adjust the default behaviour of the widget. These options should be in the form of a JSON string with proper quoting of keys. </p><p>This section may be left blank for default behaviour.</p><p>For a full list of possible options <a href="https://addressfinder.nz/docs/widget_docs/">see our Widget documentation</a></p>', 'text-domain' ),
+    $settings[] = array(
+			'type' => 'sectionend',
+			'id'   => 'addressfinder-general',
 		);
 
-		$settings[] = array(
-			'name' => __( 'Debug Mode', 'text-domain' ),
-			'id'   => 'af-debug',
-			'type' => 'checkbox',
-			'desc' => __( 'Show error messages when expected fields are missing', 'text-domain' ),
+    $settings[] = array(
+			'name' => __( 'Address Verification', 'text-domain' ),
+			'type' => 'title',
+			'id'   => 'addressfinder-widget',
 		);
 
-		$settings[] = array(
+    $settings[] = array(
 			'name'    => __( 'Default Country', 'text-domain' ),
-			'desc'    => __( 'If your checkout page does not have a country select field, addresses from this country will be displayed', 'text-domain' ),
+			'desc'    => __( 'If your checkout page does not have a country select field, addresses from this country will be displayed.', 'text-domain' ),
 			'id'      => 'af-default-country',
 			'default' => 'AU',
 			'type'    => 'select',
@@ -157,9 +222,172 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			),
 		);
 
+    $settings[] = array(
+      'name'    => __( 'Australian Address Options', 'text-domain' ),
+			'id'      => 'af-widget-au-options',
+			'default' => 'postal_and_physical',
+			'type'    => 'radio',
+			'options' => array(
+        'postal_and_physical' => __( 'Search all addresses (Postal and Physical)', 'text-domain' ),
+				'postal' => __( 'Search Australia Post delivered addresses only', 'text-domain' ),
+				'physical' => __( 'Search physical addresses only', 'text-domain' ),
+			),
+		);
+
+    $settings[] = array(
+			'id'   => 'af-widget-au-pobox',
+			'type' => 'checkbox',
+			'desc' => __( 'Include PO Boxes', 'text-domain' ),
+      'default' => 'yes'
+		);
+
+    $settings[] = array(
+      'name'    => __( 'New Zealand Address Options', 'text-domain' ),
+			'id'      => 'af-widget-nz-options',
+			'default' => 'postal_and_physical',
+			'type'    => 'radio',
+			'options' => array(
+        'postal_and_physical' => __( 'Search all addresses (Postal and Physical)', 'text-domain' ),
+				'postal' => __( 'Search New Zealand Post delivered addresses only', 'text-domain' )
+			),
+		);
+
+    $settings[] = array(
+			'id'   => 'af-widget-nz-pobox',
+			'type' => 'checkbox',
+			'desc' => __( 'Include PO Boxes', 'text-domain' ),
+      'default' => 'yes'
+		);
+
+		$settings[] = array(
+			'name'        => __( 'Advanced Javascript Options', 'text-domain' ),
+			'id'          => 'af-widget-options',
+			'type'        => 'textarea',
+      'desc_tip' => __( 'This will override the above options.', 'text-domain' ),
+      'placeholder' => __( 'Eg: {"address_params": {"source": "gnaf,paf"}}', 'text-domain' ),
+			'desc'        => __( '<p>Examples can be found <a href="https://addressfinder.nz/docs/code-examples/">here</a>.</p>', 'text-domain' ),
+		);
+
 		$settings[] = array(
 			'type' => 'sectionend',
 			'id'   => 'addressfinder-widget',
+		);
+
+    $settings[] = array(
+			'name' => __( 'Email Verification', 'text-domain' ),
+			'type' => 'title',
+			'id'   => 'addressfinder-ev-widget',
+		);
+
+    $settings[] = array(
+			'name' => __( 'Enable', 'text-domain' ),
+			'id'   => 'af-ev-widget-enabled',
+			'type' => 'checkbox',
+			'desc' => __( 'Verify email addresses at the point of capture', 'text-domain' ),
+		);
+
+    $settings[] = array(
+			'name' => __( 'Allowed Email Types', 'text-domain' ),
+			'id'   => 'af-ev-widget-public',
+			'type' => 'checkbox',
+			'desc' => __( 'Public', 'text-domain' ),
+      'default' => 'yes'
+		);
+
+    $settings[] = array(
+			'id'   => 'af-ev-widget-role',
+			'type' => 'checkbox',
+			'desc' => __( 'Role', 'text-domain' ),
+      'default' => 'yes'
+		);
+
+    $settings[] = array(
+			'id'   => 'af-ev-widget-disposable',
+			'type' => 'checkbox',
+			'desc' => __( 'Disposable', 'text-domain' ),
+		);
+
+    $settings[] = array(
+			'id'   => 'af-ev-widget-unverified',
+			'type' => 'checkbox',
+			'desc' => __( 'Unverified', 'text-domain' ),
+		);
+
+    $settings[] = array(
+			'name'        => __( 'Advanced Email Rules', 'text-domain' ),
+			'id'          => 'af-ev-widget-options',
+			'type'        => 'textarea',
+      'desc_tip' => __( 'This will override the above allowed email types.', 'text-domain' ),
+      'placeholder' => __( 'Eg: {"public": {"rule": "warn"}}', 'text-domain' ),
+			'desc'        => __( '<p>Examples can be found <a target="_blank" href="https://addressfinder.nz/docs/email/advanced_usage/#custom-rules-messages">here</a>.</p>', 'text-domain' ),
+		);
+
+    $settings[] = array(
+			'type' => 'sectionend',
+			'id'   => 'addressfinder-ev-widget',
+		);
+
+    $settings[] = array(
+			'name' => __( 'Phone Verification', 'text-domain' ),
+			'type' => 'title',
+			'id'   => 'addressfinder-pv-widget',
+		);
+
+    $settings[] = array(
+			'name' => __( 'Enable', 'text-domain' ),
+			'id'   => 'af-pv-widget-enabled',
+			'type' => 'checkbox',
+			'desc' => __( 'Verify phone numbers at the point of capture', 'text-domain' ),
+		);
+
+    $settings[] = array(
+			'name'        => __( 'Default Country', 'text-domain' ),
+			'id'          => 'af-pv-widget-default-country',
+			'type'        => 'text',
+			'desc'        => __( 'Used to determine what location to query.', 'text-domain' ),
+		);
+
+    $settings[] = array(
+			'name'        => __( 'Allowed Countries', 'text-domain' ),
+			'id'          => 'af-pv-widget-allowed-countries',
+			'type'        => 'text',
+      'placeholder' => __( 'AU,NZ', 'text-domain' ),
+			'desc'        => __( '<p>Seperate country codes by a comma.</p><p>A full list of Country Codes can be found <a target="_blank" href="https://www.iban.com/country-codes">here</a>.</p>', 'text-domain' ),
+		);
+
+    $settings[] = array(
+      'name' => __( 'Allowed Line Types', 'text-domain' ),
+ 			'id'   => 'af-pv-widget-non-mobile',
+			'type' => 'checkbox',
+			'desc' => __( 'Non Mobile', 'text-domain' ),
+      'default' => 'yes'
+		);
+
+    $settings[] = array(
+			'id'   => 'af-pv-widget-disallowed-country',
+			'type' => 'checkbox',
+			'desc' => __( 'Disallowed Countries', 'text-domain' ),
+      'default' => 'yes'
+		);
+
+    $settings[] = array(
+			'id'   => 'af-pv-widget-unverified',
+			'type' => 'checkbox',
+			'desc' => __( 'Unverified', 'text-domain' ),
+		);
+
+    $settings[] = array(
+			'name'        => __( 'Advanced Phone Rules', 'text-domain' ),
+			'id'          => 'af-pv-widget-options',
+			'type'        => 'textarea',
+      'desc_tip' => __( 'This will override the above accepted line types.', 'text-domain' ),
+      'placeholder' => __( 'Eg: {"unverified": {"rule": "warn"}}', 'text-domain' ),
+			'desc'        => __( '<p>Examples can be found <a target="_blank" href="https://addressfinder.nz/docs/phone/advanced_usage/#custom-rules-messages">here</a>.</p>', 'text-domain' ),
+		);
+
+    $settings[] = array(
+			'type' => 'sectionend',
+			'id'   => 'addressfinder-pv-widget',
 		);
 
 		return $settings;


### PR DESCRIPTION
So the platform plugins all use the `addressfinder-webpage-tools` to manage the address widget logic pretty much. I have not opted to add the PV and EV in that space/repo as the disruptions to the other plugins will be unknown and the complexity will be much greater. If we are wanting to kind of go down that route we will probably need a 'linear project' of its own to accomplish it and more man power/planning for sure.